### PR TITLE
Add Renovate configuration with node-fetch exclusion

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>dev-hato/renovate-config"],
+  "ignoreDeps": ["node-fetch"]
+}


### PR DESCRIPTION
Configure Renovate to automatically update dependencies by extending https://github.com/dev-hato/renovate-config preset. Exclude node-fetch from updates to prevent textlint execution hangs that occur with versions newer than 2.6.12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)